### PR TITLE
Ensure work around before bundled firmware check

### DIFF
--- a/octoprint_ender3v2tempfix/__init__.py
+++ b/octoprint_ender3v2tempfix/__init__.py
@@ -60,6 +60,6 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.comm.protocol.temperatures.received": __plugin_implementation__.TempReport,
-        "octoprint.comm.protocol.gcode.received": __plugin_implementation__.check_for_temp_report,
+        "octoprint.comm.protocol.gcode.received": (__plugin_implementation__.check_for_temp_report, 1),
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
     }


### PR DESCRIPTION
OctoPrint-FirmwareCheck checks for known firmware issues. For that it parses received lines,
capability reports and M115 output. See https://github.com/OctoPrint/OctoPrint-FirmwareCheck

I'd like to push firmware checks for the issue this plugin works around. For that to be possible
however this plugin needs to apply its workaround before the check runs. This can be
achieved by giving the fixing hook handler a higher priority through its order number, here 1. 
The check runs with no specific order number, and thus always after anything that has one set.

I have already implemented the firmware check in question, if you want to take a look:

https://github.com/OctoPrint/OctoPrint-FirmwareCheck/commit/6c9213050058e78a780ecc3f268cecb3391b241e